### PR TITLE
q.sh: Handle TMPDIR without trailing slash

### DIFF
--- a/q.sh
+++ b/q.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 logfile="q"
-logpath=$TMPDIR$logfile
+logpath=$TMPDIR/$logfile
 
 if [[ -z "$TMPDIR" ]]; then
 	if [[ -e "/system/bin/adb" ]]; then


### PR DESCRIPTION
Sweet little library that you've got here.

Patch is to make q.sh correctly find the output file in the cases where TMPDIR does not end in a trailing slash. Admittedly, this happened because I had to manually set TMPDIR within a docker container and just didn't add it.

When TMPDIR=/tmp then logpath=/tmpq despite the go library correctly writing to /tmp/q. With this change logpath=/tmp/q when TMPDIR=/tmp, and logpath=/tmp//q when TMPDIR=/tmp/ which still works just fine.

Hope this is useful 👍 