### PR TITLE
Added possibility to flush on stdout based on conditional environ variable

### DIFF
--- a/q.go
+++ b/q.go
@@ -19,13 +19,13 @@ type color string
 
 const (
 	// ANSI color escape codes
-	bold     color = "\033[1m"
-	yellow   color = "\033[33m"
-	cyan     color = "\033[36m"
-	endColor color = "\033[0m" // "reset everything"
-	OutEnv = "OUT"
-	maxLineWidth = 80
-	bufSize      = 16384
+	bold         color = "\033[1m"
+	yellow       color = "\033[33m"
+	cyan         color = "\033[36m"
+	endColor     color = "\033[0m" // "reset everything"
+	OutEnv             = "OUT"
+	maxLineWidth       = 80
+	bufSize            = 16384
 )
 
 // The q logger singleton
@@ -36,7 +36,6 @@ type flusher interface {
 }
 
 type fileFlusher struct {
-
 }
 
 func (ff fileFlusher) Flush(buf *bytes.Buffer) error {
@@ -52,14 +51,13 @@ func (ff fileFlusher) Flush(buf *bytes.Buffer) error {
 	return fmt.Errorf("failed to flush q buffer: %v", err)
 }
 
-type stdOutFlusher struct {}
+type stdOutFlusher struct{}
 
 func (sf stdOutFlusher) Flush(buf *bytes.Buffer) error {
 	fmt.Printf(buf.String())
 	buf.Reset()
 	return nil
 }
-
 
 // logger writes pretty logs to the $TMPDIR/q file. It takes care of opening and
 // closing the file. It is safe for concurrent use.
@@ -70,7 +68,7 @@ type logger struct {
 	timer    *time.Timer   // when it gets to 0, start a new log group
 	lastFile string        // last file to call q.Q(). determines when to print header
 	lastFunc string        // last function to call q.Q()
-	flusher flusher
+	flusher  flusher
 }
 
 // init creates the standard logger.
@@ -83,8 +81,8 @@ func init() {
 	buf := &bytes.Buffer{}
 	buf.Grow(bufSize)
 	std = &logger{
-		buf:   buf,
-		timer: t,
+		buf:     buf,
+		timer:   t,
 		flusher: fileFlusher{},
 	}
 	if os.Getenv(OutEnv) == "stdout" {

--- a/q.go
+++ b/q.go
@@ -23,13 +23,43 @@ const (
 	yellow   color = "\033[33m"
 	cyan     color = "\033[36m"
 	endColor color = "\033[0m" // "reset everything"
-
+	OutEnv = "OUT"
 	maxLineWidth = 80
 	bufSize      = 16384
 )
 
 // The q logger singleton
 var std *logger
+
+type flusher interface {
+	Flush(*bytes.Buffer) error
+}
+
+type fileFlusher struct {
+
+}
+
+func (ff fileFlusher) Flush(buf *bytes.Buffer) error {
+	path := filepath.Join(os.TempDir(), "q")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %v", path, err)
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, buf)
+	buf.Reset()
+	return fmt.Errorf("failed to flush q buffer: %v", err)
+}
+
+type stdOutFlusher struct {}
+
+func (sf stdOutFlusher) Flush(buf *bytes.Buffer) error {
+	fmt.Printf(buf.String())
+	buf.Reset()
+	return nil
+}
+
 
 // logger writes pretty logs to the $TMPDIR/q file. It takes care of opening and
 // closing the file. It is safe for concurrent use.
@@ -40,6 +70,7 @@ type logger struct {
 	timer    *time.Timer   // when it gets to 0, start a new log group
 	lastFile string        // last file to call q.Q(). determines when to print header
 	lastFunc string        // last function to call q.Q()
+	flusher flusher
 }
 
 // init creates the standard logger.
@@ -54,6 +85,12 @@ func init() {
 	std = &logger{
 		buf:   buf,
 		timer: t,
+		flusher: fileFlusher{},
+	}
+	if os.Getenv(OutEnv) == "stdout" {
+		std.flusher = stdOutFlusher{}
+	} else {
+		std.flusher = fileFlusher{}
 	}
 }
 
@@ -97,16 +134,7 @@ func (l *logger) resetTimer(d time.Duration) (expired bool) {
 
 // flush writes the logger's buffer to disk.
 func (l *logger) flush() error {
-	path := filepath.Join(os.TempDir(), "q")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open %q: %v", path, err)
-	}
-	defer f.Close()
-
-	_, err = io.Copy(f, l.buf)
-	l.buf.Reset()
-	return fmt.Errorf("failed to flush q buffer: %v", err)
+	return l.flusher.Flush(l.buf)
 }
 
 // output writes to the log buffer. Each log message is prepended with a


### PR DESCRIPTION



If we run it like ```go run main.go``` we will have Q output in $TMPDIR/q, but if we run it with environ variable we will have Q output on std 
```
➜  /tmp OUT="stdout" go run main.go
Hello world
{[{somelabel somevalue}] Outer name}

[12:41:41 tmp/main.go:27 main.main]
0.000s t=main.myStruct{
           labels: {
               {label:"somelabel", value:"somevalue"},
           },
           name: "Outer name",
       }
```


Test file:
```
package main

import "github.com/soider/q"
import "fmt"


type myStruct struct {
	labels []innerStruct
	name string
}

type innerStruct struct {
	label string
	value string
}

func main() {
	t := myStruct{}
	t.name = "Outer name"
	t.labels = make([]innerStruct, 1, 1)
	t.labels[0] = innerStruct{
	label: "somelabel",
	value: "somevalue",
}
	fmt.Println("Hello world")
	fmt.Println(t)
	q.Q(t)
}
```