### PR TITLE
Fix GOPATH handling in qq alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ go get -u github.com/y0ssar1an/q
 Put these aliases in your shell config. Typing `qq` will then start tailing
 `$TMPDIR/q`.
 ```sh
-alias qq="$GOPATH/src/github.com/y0ssar1an/q/q.sh"
+alias qq="$(echo "$GOPATH" | cut -d : -f 1)/src/github.com/y0ssar1an/q/q.sh"
 alias rmqq="rm $TMPDIR/q"
 ```
 


### PR DESCRIPTION
GOPATH is a list of directories, not a single directory, as documented at
https://golang.org/cmd/go/#hdr-GOPATH_environment_variable . This change
fixes the qq alias to handle it correctly in Unix environments.

The lack of Windows support in the fix should be fine since the original
alias was already broken on Windows.