### PR TITLE
argName: Handle *ast.Ident with nil Obj

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -26,7 +26,10 @@ func argName(arg ast.Expr) string {
 	name := ""
 	switch a := arg.(type) {
 	case *ast.Ident:
-		if a.Obj.Kind == ast.Var || a.Obj.Kind == ast.Con {
+		switch {
+		case a.Obj == nil:
+			name = a.Name
+		case a.Obj.Kind == ast.Var, a.Obj.Kind == ast.Con:
 			name = a.Obj.Name
 		}
 	case *ast.BinaryExpr,

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -336,6 +336,15 @@ func TestExtractingArgsFromSourceText(t *testing.T) {
 			},
 			want: "-1",
 		},
+		{
+			id: 16,
+			arg: &ast.Ident{
+				NamePos: 65,
+				Name:    "string",
+				Obj:     nil,
+			},
+			want: "string",
+		},
 	}
 
 	// We can test both exprToString() and argName() with the test cases above.


### PR DESCRIPTION
Would panic in cases where the Obj for an Ident was nil. Not
sure when this applies (in general) but one case was given in
from a test file.

Fixes #15