### PR TITLE
Replace timer with lastWrite timestamp

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,141 @@
+// Copyright 2016 Ryan Boehning. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package q
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type color string
+
+const (
+	// ANSI color escape codes
+	bold     color = "\033[1m"
+	yellow   color = "\033[33m"
+	cyan     color = "\033[36m"
+	endColor color = "\033[0m" // "reset everything"
+
+	maxLineWidth = 80
+)
+
+// logger writes pretty logs to the $TMPDIR/q file. It takes care of opening and
+// closing the file. It is safe for concurrent use.
+type logger struct {
+	mu        sync.Mutex    // protects all the other fields
+	buf       *bytes.Buffer // collects writes before they're flushed to the log file
+	start     time.Time     // time of first write in the current log group
+	lastWrite time.Time     // last time buffer was flushed. determines when to print header
+	lastFile  string        // last file to call q.Q(). determines when to print header
+	lastFunc  string        // last function to call q.Q(). determines when to print header
+}
+
+// header returns a formatted header string, e.g. [14:00:36 main.go main.main:122]
+// if the 2s timer has expired, or the calling function or filename has changed.
+// If none of those things are true, it returns an empty string.
+func (l *logger) header(funcName, file string, line int) string {
+	if !l.shouldPrintHeader(funcName, file) {
+		return ""
+	}
+
+	now := time.Now().UTC()
+	l.start = now
+	l.lastFunc = funcName
+	l.lastFile = file
+
+	return fmt.Sprintf("[%s %s:%d %s]", now.Format("15:04:05"), shortFile(file), line, funcName)
+}
+
+func (l *logger) shouldPrintHeader(funcName, file string) bool {
+	if file != l.lastFile {
+		return true
+	}
+
+	if funcName != l.lastFunc {
+		return true
+	}
+
+	// If less than 2s has elapsed, this log line will be printed under the
+	// previous header.
+	const timeWindow = 2 * time.Second
+
+	return time.Since(l.lastWrite) > timeWindow
+}
+
+// flush writes the logger's buffer to disk.
+func (l *logger) flush() (err error) {
+	path := filepath.Join(os.TempDir(), "q")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %v", path, err)
+	}
+	defer func() {
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+		l.lastWrite = time.Now()
+	}()
+
+	_, err = io.Copy(f, l.buf)
+	l.buf.Reset()
+	if err != nil {
+		return fmt.Errorf("failed to flush q buffer: %v", err)
+	}
+
+	return nil
+}
+
+// output writes to the log buffer. Each log message is prepended with a
+// timestamp. Long lines are broken at 80 characters.
+func (l *logger) output(args ...string) {
+	timestamp := fmt.Sprintf("%.3fs", time.Since(l.start).Seconds())
+	timestampWidth := len(timestamp) + 1 // +1 for padding space after timestamp
+	timestamp = colorize(timestamp, yellow)
+
+	// preWidth is the length of everything before the log message.
+	fmt.Fprint(l.buf, timestamp, " ")
+
+	// Subsequent lines have to be indented by the width of the timestamp.
+	indent := strings.Repeat(" ", timestampWidth)
+	padding := "" // padding is the space between args.
+	lineArgs := 0 // number of args printed on the current log line.
+	lineWidth := timestampWidth
+	for _, arg := range args {
+		argWidth := argWidth(arg)
+		lineWidth += argWidth + len(padding)
+
+		// Some names in name=value strings contain newlines. Insert indentation
+		// after each newline so they line up.
+		arg = strings.Replace(arg, "\n", "\n"+indent, -1)
+
+		// Break up long lines. If this is first arg printed on the line
+		// (lineArgs == 0), it makes no sense to break up the line.
+		if lineWidth > maxLineWidth && lineArgs != 0 {
+			fmt.Fprint(l.buf, "\n", indent)
+			lineArgs = 0
+			lineWidth = timestampWidth + argWidth
+			padding = ""
+		}
+		fmt.Fprint(l.buf, padding, arg)
+		lineArgs++
+		padding = " "
+	}
+
+	fmt.Fprint(l.buf, "\n")
+}
+
+// shortFile takes an absolute file path and returns just the <directory>/<file>,
+// e.g. "foo/bar.go".
+func shortFile(file string) string {
+	dir := filepath.Base(filepath.Dir(file))
+	file = filepath.Base(file)
+	return filepath.Join(dir, file)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -73,13 +73,13 @@ func TestHeader(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		timer := getTimer(tc.timerExpired)
-
 		l := &logger{
 			buf:      &bytes.Buffer{},
-			timer:    timer,
 			lastFile: tc.lastFile,
 			lastFunc: tc.lastFunc,
+		}
+		if !tc.timerExpired {
+			l.lastWrite = time.Now()
 		}
 
 		const line = 123
@@ -103,18 +103,6 @@ func TestHeader(t *testing.T) {
 	}
 }
 
-// getTimer returns an expire timer or a 5s timer.
-func getTimer(expired bool) *time.Timer {
-	var timer *time.Timer
-	if expired {
-		timer = time.NewTimer(0)
-		timer.Stop()
-	} else {
-		timer = time.NewTimer(5 * time.Second)
-	}
-	return timer
-}
-
 // TestOutput verifies that logger.output() prints the expected output to the
 // log buffer.
 func TestOutput(t *testing.T) {
@@ -126,7 +114,6 @@ func TestOutput(t *testing.T) {
 			args: []string{fmt.Sprintf("%s=%s", colorize("a", bold), colorize("int(1)", cyan))},
 			want: fmt.Sprintf("%s %s=%s\n", colorize("0.000s", yellow), colorize("a", bold), colorize("int(1)", cyan)),
 		},
-		// TODO: more tests
 	}
 
 	for _, tc := range testCases {

--- a/q.go
+++ b/q.go
@@ -7,154 +7,15 @@ package q
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"time"
 )
 
-type color string
-
-const (
-	// ANSI color escape codes
-	bold     color = "\033[1m"
-	yellow   color = "\033[33m"
-	cyan     color = "\033[36m"
-	endColor color = "\033[0m" // "reset everything"
-
-	maxLineWidth = 80
-	bufSize      = 16384
-)
-
-// The q logger singleton
-var std *logger
-
-// logger writes pretty logs to the $TMPDIR/q file. It takes care of opening and
-// closing the file. It is safe for concurrent use.
-type logger struct {
-	mu       sync.Mutex    // protects all the other fields
-	buf      *bytes.Buffer // collects writes before they're flushed to the log file
-	start    time.Time     // time of first write in the current log group
-	timer    *time.Timer   // when it gets to 0, start a new log group
-	lastFile string        // last file to call q.Q(). determines when to print header
-	lastFunc string        // last function to call q.Q()
-}
-
-// init creates the standard logger.
-func init() {
-	// Starting with 0 time doesn't mean the timer is stopped, so we must
-	// explicitly stop the timer.
-	t := time.NewTimer(0)
-	t.Stop()
-
-	buf := &bytes.Buffer{}
-	buf.Grow(bufSize)
+// nolint: gochecknoglobals
+var (
+	// std is the singleton logger.
 	std = &logger{
-		buf:   buf,
-		timer: t,
+		buf: &bytes.Buffer{},
 	}
-}
-
-// header returns a formatted header string, e.g. [14:00:36 main.go main.main:122]
-// if the 2s timer has expired, or the calling function or filename has changed.
-// If none of those things are true, it returns an empty string.
-func (l *logger) header(funcName, file string, line int) string {
-	// Reset the 2s timer.
-	timerExpired := l.resetTimer(2 * time.Second)
-
-	if !timerExpired && funcName == l.lastFunc && file == l.lastFile {
-		// Don't print a header line.
-		return ""
-	}
-
-	l.lastFunc = funcName
-	l.lastFile = file
-
-	now := time.Now().UTC().Format("15:04:05")
-
-	return fmt.Sprintf("[%s %s:%d %s]", now, shortFile(file), line, funcName)
-}
-
-// shortFile takes an absolute file path and returns just the <directory>/<file>,
-// e.g. "foo/bar.go".
-func shortFile(file string) string {
-	dir := filepath.Base(filepath.Dir(file))
-	file = filepath.Base(file)
-	return filepath.Join(dir, file)
-}
-
-// resetTimer resets the logger's timer to the given time. It returns true if
-// the timer had expired before it was reset.
-func (l *logger) resetTimer(d time.Duration) (expired bool) {
-	expired = !l.timer.Reset(d)
-	if expired {
-		l.start = time.Now()
-	}
-	return expired
-}
-
-// flush writes the logger's buffer to disk.
-func (l *logger) flush() (err error) {
-	path := filepath.Join(os.TempDir(), "q")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open %q: %v", path, err)
-	}
-	defer func() {
-		if cerr := f.Close(); err == nil {
-			err = cerr
-		}
-	}()
-
-	_, err = io.Copy(f, l.buf)
-	l.buf.Reset()
-	if err != nil {
-		return fmt.Errorf("failed to flush q buffer: %v", err)
-	}
-
-	return nil
-}
-
-// output writes to the log buffer. Each log message is prepended with a
-// timestamp. Long lines are broken at 80 characters.
-func (l *logger) output(args ...string) {
-	timestamp := fmt.Sprintf("%.3fs", time.Since(l.start).Seconds())
-	timestampWidth := len(timestamp) + 1 // +1 for padding space after timestamp
-	timestamp = colorize(timestamp, yellow)
-
-	// preWidth is the length of everything before the log message.
-	fmt.Fprint(l.buf, timestamp, " ")
-
-	// Subsequent lines have to be indented by the width of the timestamp.
-	indent := strings.Repeat(" ", timestampWidth)
-	padding := "" // padding is the space between args.
-	lineArgs := 0 // number of args printed on the current log line.
-	lineWidth := timestampWidth
-	for _, arg := range args {
-		argWidth := argWidth(arg)
-		lineWidth += argWidth + len(padding)
-
-		// Some names in name=value strings contain newlines. Insert indentation
-		// after each newline so they line up.
-		arg = strings.Replace(arg, "\n", "\n"+indent, -1)
-
-		// Break up long lines. If this is first arg printed on the line
-		// (lineArgs == 0), it makes no sense to break up the line.
-		if lineWidth > maxLineWidth && lineArgs != 0 {
-			fmt.Fprint(l.buf, "\n", indent)
-			lineArgs = 0
-			lineWidth = timestampWidth + argWidth
-			padding = ""
-		}
-		fmt.Fprint(l.buf, padding, arg)
-		lineArgs++
-		padding = " "
-	}
-
-	fmt.Fprint(l.buf, "\n")
-}
+)
 
 // Q pretty-prints the given arguments to the $TMPDIR/q log file.
 func Q(v ...interface{}) {


### PR DESCRIPTION
`q.Q()` calls in the same function in the same file that occur within 2s of each other are grouped under the same header.
```
[14:00:36 main.go main.main:122]
```
I was using a `*time.Timer` object to track the 2s intervals to determine if a new header line needed to be printed. This is a somewhat complicated object that uses a channel internally. It's simpler and faster to replace the timer object with a timestamp for tracking the time since the last write. This enables me to remove `init()`.

I also moved the logger type and methods to a separate `logger.go` file.