### PR TITLE
Fix `rmqq` sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ qq() {
 }
 
 rmqq() {
-    if [[ -f "$TMPDIR/q" ]]; then
-        rm "$TMPDIR/q"
+    logpath="$TMPDIR/q"
+    if [[ -z "$TMPDIR" ]]; then
+        logpath="/tmp/q"
+    fi
+    if [[ -f "$logpath" ]]; then
+        rm "$logpath"
     fi
     qq
 }


### PR DESCRIPTION
This PR fixes `rmqq` command in the sh script for when `$TMPDIR` is unset.