### PR TITLE
Set $GOFLAGS to '-mod=vendor'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ executors:
       - image: golang:1.11
     environment:
       GO111MODULE: 'on'
+      GOFLAGS: '-mod=vendor'
     working_directory: /go/src/github.com/y0ssar1an/q
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
       - restore_cache:
           keys:
             - go-pkgs-{{ checksum "go.sum" }}
-      - run: go install -mod vendor github.com/y0ssar1an/q/vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
+      - run: go install github.com/y0ssar1an/q/vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
       - run: golangci-lint run
   test:
     executor:
@@ -27,7 +28,7 @@ jobs:
       - restore_cache:
           keys:
             - go-pkgs-{{ checksum "go.sum" }}
-      - run: go test -mod vendor -v -race ./...
+      - run: go test -v -race ./...
       - save_cache:  # cache the /go/pkg directory
           key: go-pkgs-{{ checksum "go.sum" }}
           paths:


### PR DESCRIPTION
This lets us delete the `-mod=vendor` flag in two places