### PR TITLE
Inline buffer in logger to avoid pointer indirection

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -72,7 +72,7 @@ func TestHeader(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		l := &logger{
+		l := logger{
 			lastFile: tc.lastFile,
 			lastFunc: tc.lastFunc,
 		}

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,7 +5,6 @@
 package q
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,7 +73,6 @@ func TestHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		l := &logger{
-			buf:      &bytes.Buffer{},
 			lastFile: tc.lastFile,
 			lastFunc: tc.lastFunc,
 		}
@@ -117,11 +115,10 @@ func TestOutput(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		buf := &bytes.Buffer{}
-		l := logger{buf: buf, start: time.Now().UTC()}
+		l := logger{start: time.Now().UTC()}
 		l.output(tc.args...)
 
-		got := buf.String()
+		got := l.buf.String()
 		if got != tc.want {
 			argString := strings.Join(tc.args, ", ")
 			t.Fatalf("\nlogger.output(%s)\ngot:  %swant: %s", argString, got, tc.want)

--- a/q.go
+++ b/q.go
@@ -11,7 +11,7 @@ import (
 // nolint: gochecknoglobals
 var (
 	// std is the singleton logger.
-	std = &logger{}
+	std logger
 )
 
 // Q pretty-prints the given arguments to the $TMPDIR/q log file.

--- a/q.go
+++ b/q.go
@@ -5,16 +5,13 @@
 package q
 
 import (
-	"bytes"
 	"fmt"
 )
 
 // nolint: gochecknoglobals
 var (
 	// std is the singleton logger.
-	std = &logger{
-		buf: &bytes.Buffer{},
-	}
+	std = &logger{}
 )
 
 // Q pretty-prints the given arguments to the $TMPDIR/q log file.
@@ -41,7 +38,7 @@ func Q(v ...interface{}) {
 	// A header line looks like this: [14:00:36 main.go main.main:122].
 	header := std.header(funcName, file, line)
 	if header != "" {
-		fmt.Fprint(std.buf, "\n", header, "\n")
+		fmt.Fprint(&std.buf, "\n", header, "\n")
 	}
 
 	// q.Q(foo, bar, baz) -> []string{"foo", "bar", "baz"}


### PR DESCRIPTION
- Inline the `bytes.Buffer` into the `logger` struct to avoid one level of pointer indirection.
- Declare the singleton logger without pointer indirection