### PR TITLE
Fetch golangci-lint in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   go-container:
     docker:
-      - image: golang:1.11
+      - image: golang:1.12
     environment:
       GO111MODULE: 'on'
       GOFLAGS: '-mod=vendor'
@@ -18,7 +18,7 @@ jobs:
       - restore_cache:
           keys:
             - go-pkgs-{{ checksum "go.sum" }}
-      - run: go install github.com/y0ssar1an/q/vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
+      - run: GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
       - run: golangci-lint run
   test:
     executor:

--- a/README.md
+++ b/README.md
@@ -24,18 +24,12 @@ import "github.com/y0ssar1an/q"
 ...
 q.Q(a, b, c)
 ```
-```go
-// Alternatively, use the . import and you can omit the package name.
-import . "github.com/y0ssar1an/q"
-...
-Q(a, b, c)
-```
 
 For best results, dedicate a terminal to tailing `$TMPDIR/q` while you work.
 
 ## Install
 ```sh
-go get -u github.com/y0ssar1an/q
+GO111MODULE=off go get github.com/y0ssar1an/q
 ```
 
 Put these functions in your shell config. Typing `qq` or `rmqq` will then start


### PR DESCRIPTION
### changes
* update CI to use the golang:1.12 container.
* change the install instructions in the README to `GO111MODULE=off go get github.com/y0ssar1an/q` so the old `go get` behavior will be used.