### PR TITLE
Switch from golang:1.12 to golang:1.12-alpine in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.12
+      image: golang:1.12-alpine
       env:
         GO111MODULE: 'on'
         GOFLAGS: '-mod=vendor'


### PR DESCRIPTION
We don't need the full Debian-based `golang` container just to run tests. Using the smaller Alpine-based container will save a little time during CI. Note: This is only for GHA.