### PR TITLE
Update the CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,16 @@ executors:
     docker:
       - image: golang:1.13
     environment:
-      GO111MODULE: "on"
-      GOFLAGS: "-mod=vendor"
+      GO111MODULE: 'on'
+      GOFLAGS: '-mod=vendor'
     working_directory: /go/src/github.com/y0ssar1an/q
 
 jobs:
   lint:
-    executor:
-      name: go-container
+    docker:
+      - image: golangci/golangci-lint:v1.21-alpine
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-pkgs-{{ checksum "go.sum" }}
-      - run: GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
       - run: golangci-lint run
   test:
     executor:
@@ -32,7 +28,7 @@ jobs:
       - save_cache: # cache the /go/pkg directory
           key: go-pkgs-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg"
+            - '/go/pkg'
 
 workflows:
   build_and_test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,15 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    container:
+      image: golangci/golangci-lint:v1.21-alpine
+      env:
+        GO111MODULE: 'on'
+        GOFLAGS: '-mod=vendor'
     steps:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-      - name: Download and install the linter
-        run: |
-          curl -L https://github.com/golangci/golangci-lint/releases/download/v1.17.1/golangci-lint-1.17.1-linux-amd64.tar.gz | tar xzf - -C /tmp
-          sudo mv /tmp/golangci-lint-1.17.1-linux-amd64/golangci-lint /usr/local/bin/golangci-lint
       - name: Run the linter
         run: golangci-lint run
   test:
@@ -20,8 +21,8 @@ jobs:
     container:
       image: golang:1.13
       env:
-        GO111MODULE: "on"
-        GOFLAGS: "-mod=vendor"
+        GO111MODULE: 'on'
+        GOFLAGS: '-mod=vendor'
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,13 @@
 run:
-  deadline: 1m
   modules-download-mode: vendor
   tests: true
+  timeout: 1m
 
 linters:
   enable-all: true
   disable:
     - scopelint
+    - wsl
 
 linters-settings:
   gocyclo:

--- a/args.go
+++ b/args.go
@@ -23,6 +23,7 @@ import (
 // returns an empty string.
 func argName(arg ast.Expr) string {
 	name := ""
+
 	switch a := arg.(type) {
 	case *ast.Ident:
 		switch {
@@ -42,6 +43,7 @@ func argName(arg ast.Expr) string {
 		*ast.UnaryExpr:
 		name = exprToString(arg)
 	}
+
 	return name
 }
 

--- a/args_test.go
+++ b/args_test.go
@@ -15,6 +15,7 @@ import (
 // TestExtractingArgsFromSourceText verifies that exprToString() and argName()
 // arg able to extract the text of the arguments passed to q.Q(). For example,
 // q.Q(myVar) should return "myVar".
+// nolint: funlen
 func TestExtractingArgsFromSourceText(t *testing.T) {
 	testCases := []struct {
 		id   int
@@ -539,6 +540,7 @@ func TestPrependArgName(t *testing.T) {
 
 // TestIsQCall verifies that isQCall() returns true if the given call expression
 // is q.Q().
+// nolint: funlen
 func TestIsQCall(t *testing.T) {
 	testCases := []struct {
 		id   int

--- a/logger_test.go
+++ b/logger_test.go
@@ -14,6 +14,7 @@ import (
 
 // TestHeader verifies that logger.header() returns a header line with the
 // expected filename, function name, and line number.
+// nolint: funlen
 func TestHeader(t *testing.T) {
 	testCases := []struct {
 		lastFile, lastFunc string
@@ -86,15 +87,18 @@ func TestHeader(t *testing.T) {
 			if h == "" {
 				continue
 			}
+
 			t.Fatalf("\nl.header(%s, %s, %d)\ngot:  %q\nwant: %q", tc.currFunc, tc.lastFile, line, h, "")
 		}
 
 		if !strings.Contains(h, tc.currFunc) {
 			t.Fatalf("\nl.header(%s, %s, %d)\ngot:  %q\nmissing current function name", tc.currFunc, tc.currFile, line, h)
 		}
+
 		if !strings.Contains(h, tc.currFile) {
 			t.Fatalf("\nl.header(%s, %s, %d)\ngot:  %q\nmissing current file name", tc.currFunc, tc.currFile, line, h)
 		}
+
 		if !strings.Contains(h, strconv.Itoa(line)) {
 			t.Fatalf("\nl.header(%s, %s, %d)\ngot:  %q\nmissing line number", tc.currFunc, tc.currFile, line, h)
 		}


### PR DESCRIPTION
### changes
* run the linter from its own container
* update the linter to v1.21.0
* disable the new `wsl` linter
    * This is an opinionated linter about whitespace. It's really not necessary
* change `deadline` to `timeout` in the CircleCI config
    * The name of the key changed
* update the linter in the GitHub Actions CI config too