### PR TITLE
Go1.13 build fix: go.mod: go1.12 => go1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/y0ssar1an/q
+module github.com/savalin/q
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/y0ssar1an/q
 
-go 1.12
+go 1.13
 
 require github.com/kr/pretty v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/savalin/q
+module github.com/y0ssar1an/q
 
 go 1.13
 


### PR DESCRIPTION
Using go1.13.7 for building my project (that uses github.com/y0ssar1an/q as a dependency) I got the error:
```
github.com/y0ssar1an/q@v1.0.8 requires
github.com/golangci/golangci-lint@v1.12.2 requires
github.com/golangci/tools@v0.0.0-20180902102414-2cefd77fef9b: invalid version: unknown revision 2cefd77fef9b
```
I've cloned the repository, made local changes in go.mod (just set up go1.13)
```diff --git a/go.mod b/go.mod
index 86f936a..092e9a3 100644
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/y0ssar1an/q

-go 1.12
+go 1.13

 require github.com/kr/pretty v0.2.0
(END)
```
used the 'replace' in my project's go.mod (from github.com/y0ssar1an/q to local copy) - and that helped.

At the same time, it works without any go.mod changes when I used go1.12.13 for the project build.
Also, after making these go.mod changes I stay able to build the project using go1.12.

It seems it could be better to use go1.13 in master to avoid problems like this one.