### PR TITLE
Update to Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,8 @@ version: 2.1
 executors:
   go-container:
     docker:
-      - image: golang:1.13
-    environment:
-      GO111MODULE: 'on'
-      GOFLAGS: -mod=vendor
-    working_directory: /go/src/github.com/y0ssar1an/q
+      - image: golang:1.14
+    working_directory: /go/src/q
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.13
-      env:
-        GO111MODULE: 'on'
-        GOFLAGS: -mod=vendor
+      image: golang:1.14
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For best results, dedicate a terminal to tailing `$TMPDIR/q` while you work.
 
 ## Install
 ```sh
-GO111MODULE=off go get github.com/y0ssar1an/q
+go get -u github.com/y0ssar1an/q
 ```
 
 Put these functions in your shell config. Typing `qq` or `rmqq` will then start

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/y0ssar1an/q
 
-go 1.13
+go 1.14
 
 require github.com/kr/pretty v0.2.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # github.com/kr/pretty v0.2.0
+## explicit
 github.com/kr/pretty
 # github.com/kr/text v0.1.0
 github.com/kr/text


### PR DESCRIPTION
- Update required `go` version in `go.mod` to 1.14
- Update CI runners to use `golang:1.14` image
- Remove `-mod=vendor` and `GO111MODULE=on` flags from everywhere